### PR TITLE
Print and Run Flag for manual command

### DIFF
--- a/mshx
+++ b/mshx
@@ -142,6 +142,14 @@ if [ "$command" == "manual" ]; then
     echo "---------"
     help_command
 
+    # if -p flag is passed with manual
+    if [[ "$2" == "-p" ]]; then
+        echo ""
+        echo "-------- Script Content --------"
+        cat "$0"
+        echo -e "\n"
+        echo "-------------------------------"
+    fi
 
     # For not allowing script to stop, using while loop
     while true; do

--- a/mshx
+++ b/mshx
@@ -39,7 +39,7 @@ function install_command(){
     extension="$2"
 
     if [ -z "$extension" ]; then
-        echo "No extension specified. Type 'mshx help' for help."
+        echo "No extension specified. Type 'mshx help' or 'mshx manual' for help."
         exit 1
     fi
 
@@ -136,4 +136,34 @@ if [ "$command" == "list" ] || [ "$command" == "ls" ]; then
     exit 0
 fi
 
-echo "Command not found. Type 'mshx help' for help."
+# Addition of manual flag
+if [ "$command" == "manual" ]; then
+    echo "Manual"
+    echo "---------"
+    help_command
+
+
+    # For not allowing script to stop, using while loop
+    while true; do
+        echo ""
+        echo "What do you want to do now"
+        echo "1) Run install"
+        echo "2) Show list"
+        echo "3) Show help again"
+        echo "4) exit"
+        read -p "> " input
+
+        case $input in
+            1) read -p "Enter Extension name (format: username/repo): " ext_name
+               install_command install "$ext_name"
+               break 
+            ;;
+            2) list_command; break;;
+            3) help_command; break;;
+            4) exit 0;;
+            *) echo "Invalid option. Please try again.";;
+        esac
+    done
+fi
+
+echo "Command not found. Type 'mshx help' or 'mshx manual' for help."


### PR DESCRIPTION
## Linked Issue

Issue: #36 #37 

Please select the relevant option:

-   [ ] Bug fix
-   [✅] New feature
-   [ ] New test
-   [ ] Refactoring / code cleanup
-   [ ] Documentation
-   [ ] Other (please describe here: ...)


Please provide a brief description of the changes made in this pull request:

> When the user enters the manual flag in the CLI, a looped menu is displayed instead of exiting the script. The manual now acts as a persistent interface, allowing users to interactively run commands (install, list, help, exit, etc.) until they choose to exit.
> Additionally, a -p flag is introduced. When passed as manual -p, the entire script content is printed to the terminal using cat "$0".

## Changes

Please add a list of changes made in this pull request:

-  Added a while loop inside manual if statement
-  Added a "-p" flag under the manual handler, that prints the whole script
- Solved issue #36: Keep script running after manual flag.
- Solved issue #37: Add -p flag to show script contents.
